### PR TITLE
Add double-click metadata display and fragment management improvements

### DIFF
--- a/src/web/web-canvas/electron/main/database/schema.ts
+++ b/src/web/web-canvas/electron/main/database/schema.ts
@@ -14,7 +14,13 @@ CREATE TABLE IF NOT EXISTS fragments (
     line_count INTEGER,
     script_type TEXT,
     segmentation_coords TEXT,              -- JSON: polygon coordinates
-    
+
+    -- Scale detection metadata (populated by ML models)
+    scale_unit TEXT,                       -- 'cm' or 'mm'
+    pixels_per_unit REAL,                  -- Pixels per physical unit
+    scale_detection_status TEXT,           -- 'success' or 'error: message'
+    scale_model_version TEXT,              -- Version of scale detection model used
+
     -- User-editable metadata
     notes TEXT,
     
@@ -27,6 +33,7 @@ CREATE INDEX IF NOT EXISTS idx_fragment_id ON fragments(fragment_id);
 CREATE INDEX IF NOT EXISTS idx_line_count ON fragments(line_count);
 CREATE INDEX IF NOT EXISTS idx_script_type ON fragments(script_type);
 CREATE INDEX IF NOT EXISTS idx_edge_piece ON fragments(edge_piece);
+CREATE INDEX IF NOT EXISTS idx_scale_detection ON fragments(scale_detection_status);
 
 -- Projects table: stores saved canvas projects
 CREATE TABLE IF NOT EXISTS projects (

--- a/src/web/web-canvas/electron/main/ipc/handlers.ts
+++ b/src/web/web-canvas/electron/main/ipc/handlers.ts
@@ -165,7 +165,17 @@ export function registerIpcHandlers(): void {
    * Update fragment metadata (notes, etc.)
    */
   ipcMain.handle('fragments:updateMetadata', async (_event, fragmentId: string, metadata: Record<string, unknown>) => {
-    const allowedFields = ['notes', 'edge_piece', 'has_top_edge', 'has_bottom_edge', 'line_count', 'script_type'];
+    const allowedFields = [
+      'notes',
+      'edge_piece',
+      'has_top_edge',
+      'has_bottom_edge',
+      'line_count',
+      'script_type',
+      'scale_unit',
+      'pixels_per_unit',
+      'scale_detection_status'
+    ];
     const updates: string[] = [];
     const params: unknown[] = [];
 

--- a/src/web/web-canvas/src/components/Canvas.tsx
+++ b/src/web/web-canvas/src/components/Canvas.tsx
@@ -9,6 +9,7 @@ interface CanvasProps {
   selectedFragmentIds: string[];
   onSelectionChange: (ids: string[]) => void;
   onEdgeMatch?: (fragmentId: string) => void;
+  onFragmentDoubleClick?: (fragmentId: string) => void;
   isGridVisible?: boolean;
   gridScale?: number; // pixels per cm
 }
@@ -18,6 +19,7 @@ interface FragmentImageProps {
   isSelected: boolean;
   onSelect: (e: any) => void;
   onChange: (newAttrs: Partial<CanvasFragment>) => void;
+  onDoubleClick?: () => void;
   onDragStart?: () => void;
   onDragEnd?: () => void;
   onTransformStart?: () => void;
@@ -29,6 +31,7 @@ const FragmentImage: React.FC<FragmentImageProps> = ({
   isSelected,
   onSelect,
   onChange,
+  onDoubleClick,
   onDragStart,
   onDragEnd,
   onTransformStart,
@@ -67,6 +70,12 @@ const FragmentImage: React.FC<FragmentImageProps> = ({
         draggable={!fragment.isLocked}
         onClick={(e) => onSelect(e.evt)}
         onTap={(e) => onSelect(e.evt)}
+        onDblClick={() => {
+          if (onDoubleClick) onDoubleClick();
+        }}
+        onDblTap={() => {
+          if (onDoubleClick) onDoubleClick();
+        }}
         onDragStart={() => {
           if (onDragStart) onDragStart();
         }}
@@ -115,6 +124,7 @@ const Canvas: React.FC<CanvasProps> = ({
   selectedFragmentIds,
   onSelectionChange,
   onEdgeMatch,
+  onFragmentDoubleClick,
   isGridVisible = false,
   gridScale = 25,
 }) => {
@@ -285,6 +295,11 @@ const Canvas: React.FC<CanvasProps> = ({
               isSelected={selectedFragmentIds.includes(fragment.id)}
               onSelect={(e) => handleSelect(fragment.id, e)}
               onChange={(newAttrs) => handleFragmentChange(fragment.id, newAttrs)}
+              onDoubleClick={() => {
+                if (onFragmentDoubleClick) {
+                  onFragmentDoubleClick(fragment.fragmentId);
+                }
+              }}
               onDragStart={() => setIsDragging(true)}
               onDragEnd={() => {
                 // Small delay to allow position to update before showing button

--- a/src/web/web-canvas/src/components/FragmentMetadata.tsx
+++ b/src/web/web-canvas/src/components/FragmentMetadata.tsx
@@ -1,13 +1,301 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { ManuscriptFragment } from '../types/fragment';
+import { updateFragmentMetadata, getFragmentById } from '../services/fragment-service';
+import {
+  validateLineCount,
+  validatePixelsPerUnit,
+  validateScriptType,
+  validateScaleUnit,
+} from '../utils/metadataValidation';
 
 interface FragmentMetadataProps {
   fragment: ManuscriptFragment;
   onClose: () => void;
+  onUpdate?: () => void; // Callback to refresh fragment data after edit
 }
 
-const FragmentMetadata: React.FC<FragmentMetadataProps> = ({ fragment, onClose }) => {
+const FragmentMetadata: React.FC<FragmentMetadataProps> = ({ fragment: initialFragment, onClose, onUpdate }) => {
+  const [fragment, setFragment] = useState(initialFragment);
   const { metadata } = fragment;
+
+  // Update local fragment when prop changes
+  useEffect(() => {
+    setFragment(initialFragment);
+  }, [initialFragment]);
+
+  // Edit state management
+  const [editingField, setEditingField] = useState<string | null>(null);
+  const [editValues, setEditValues] = useState<Record<string, any>>({});
+  const [savingField, setSavingField] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [saveSuccess, setSaveSuccess] = useState<string | null>(null);
+
+  const startEditing = (field: string, currentValue: any) => {
+    setEditingField(field);
+    setEditValues({ ...editValues, [field]: currentValue });
+    setFieldErrors({ ...fieldErrors, [field]: '' });
+  };
+
+  const cancelEditing = () => {
+    setEditingField(null);
+    setFieldErrors({});
+  };
+
+  const saveField = async (field: string, dbField: string, value: any) => {
+    // Validate based on field type
+    let validation;
+    if (field === 'lineCount') {
+      validation = validateLineCount(Number(value));
+    } else if (field === 'pixelsPerUnit') {
+      validation = validatePixelsPerUnit(Number(value));
+    } else if (field === 'script') {
+      validation = validateScriptType(String(value));
+    } else if (field === 'scaleUnit') {
+      validation = validateScaleUnit(String(value));
+    } else {
+      validation = { valid: true };
+    }
+
+    if (!validation.valid) {
+      setFieldErrors({ ...fieldErrors, [field]: validation.error || 'Invalid value' });
+      return;
+    }
+
+    setSavingField(field);
+    setFieldErrors({ ...fieldErrors, [field]: '' });
+
+    try {
+      const result = await updateFragmentMetadata(fragment.id, { [dbField]: value });
+
+      if (result.success) {
+        // Refetch the fragment to get updated data
+        const updatedFragment = await getFragmentById(fragment.id);
+        if (updatedFragment) {
+          setFragment(updatedFragment);
+        }
+
+        setSaveSuccess(field);
+        setTimeout(() => setSaveSuccess(null), 2000);
+        setEditingField(null);
+
+        if (onUpdate) {
+          onUpdate();
+        }
+      } else {
+        setFieldErrors({ ...fieldErrors, [field]: result.error || 'Failed to save' });
+      }
+    } catch (error) {
+      setFieldErrors({ ...fieldErrors, [field]: 'Failed to save changes' });
+    } finally {
+      setSavingField(null);
+    }
+  };
+
+  const renderEditableField = (
+    label: string,
+    icon: React.ReactNode,
+    field: string,
+    dbField: string,
+    currentValue: any,
+    displayValue: string,
+    inputType: 'text' | 'number' = 'text',
+    colorClass: string = 'blue',
+    isUndefined: boolean = false
+  ) => {
+    const isEditing = editingField === field;
+    const isSaving = savingField === field;
+    const isSuccess = saveSuccess === field;
+    const error = fieldErrors[field];
+
+    return (
+      <div className={`p-3 ${isUndefined ? 'bg-slate-50 border-slate-200' : `bg-gradient-to-r from-${colorClass}-50 to-${colorClass}-100/50 border-${colorClass}-200/50`} rounded-lg border`}>
+        <div className="flex justify-between items-center">
+          <div className="flex items-center gap-2">
+            {icon}
+            <span className="font-medium text-slate-700 text-sm">{label}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            {!isEditing ? (
+              <>
+                <span className={`px-3 py-1 rounded-md text-sm font-semibold shadow-sm ${isUndefined ? 'text-slate-400 bg-white' : 'text-slate-900 bg-white'}`}>
+                  {displayValue}
+                </span>
+                {isSuccess ? (
+                  <div className="text-emerald-600 animate-in fade-in">
+                    <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                      <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd"/>
+                    </svg>
+                  </div>
+                ) : (
+                  <button
+                    onClick={() => startEditing(field, currentValue ?? (inputType === 'number' ? 0 : ''))}
+                    className="text-slate-400 hover:text-slate-600 p-1 hover:bg-white/50 rounded transition-colors"
+                    title="Edit"
+                  >
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+                    </svg>
+                  </button>
+                )}
+              </>
+            ) : (
+              <div className="flex items-center gap-1">
+                <input
+                  type={inputType}
+                  value={editValues[field] ?? currentValue}
+                  onChange={(e) => setEditValues({ ...editValues, [field]: e.target.value })}
+                  className="w-24 px-2 py-1 text-sm border border-slate-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  autoFocus
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      saveField(field, dbField, editValues[field] ?? currentValue);
+                    } else if (e.key === 'Escape') {
+                      cancelEditing();
+                    }
+                  }}
+                />
+                <button
+                  onClick={() => saveField(field, dbField, editValues[field] ?? currentValue)}
+                  disabled={isSaving}
+                  className="text-emerald-600 hover:text-emerald-700 p-1 hover:bg-white/50 rounded transition-colors disabled:opacity-50"
+                  title="Save"
+                >
+                  {isSaving ? (
+                    <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"/>
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/>
+                    </svg>
+                  ) : (
+                    <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                      <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd"/>
+                    </svg>
+                  )}
+                </button>
+                <button
+                  onClick={cancelEditing}
+                  disabled={isSaving}
+                  className="text-slate-400 hover:text-slate-600 p-1 hover:bg-white/50 rounded transition-colors disabled:opacity-50"
+                  title="Cancel"
+                >
+                  <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                    <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd"/>
+                  </svg>
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+        {error && (
+          <div className="mt-2 text-xs text-red-600 bg-red-50 px-2 py-1 rounded">
+            {error}
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  const renderToggleField = (
+    label: string,
+    icon: React.ReactNode,
+    field: string,
+    dbField: string,
+    currentValue: boolean | undefined,
+    colorClass: string = 'emerald'
+  ) => {
+    const isSaving = savingField === field;
+    const isSuccess = saveSuccess === field;
+
+    const handleToggle = async () => {
+      const newValue = currentValue === undefined ? true : !currentValue;
+      setSavingField(field);
+
+      try {
+        const result = await updateFragmentMetadata(fragment.id, { [dbField]: newValue ? 1 : 0 });
+
+        if (result.success) {
+          // Refetch the fragment to get updated data
+          const updatedFragment = await getFragmentById(fragment.id);
+          if (updatedFragment) {
+            setFragment(updatedFragment);
+          }
+
+          setSaveSuccess(field);
+          setTimeout(() => setSaveSuccess(null), 2000);
+
+          if (onUpdate) {
+            onUpdate();
+          }
+        } else {
+          setFieldErrors({ ...fieldErrors, [field]: result.error || 'Failed to save' });
+        }
+      } catch (error) {
+        setFieldErrors({ ...fieldErrors, [field]: 'Failed to save changes' });
+      } finally {
+        setSavingField(null);
+      }
+    };
+
+    const hasValue = currentValue !== undefined;
+    const isActive = currentValue === true;
+
+    return (
+      <div className={`p-3 rounded-lg border ${
+        hasValue && isActive
+          ? `bg-gradient-to-r from-${colorClass}-50 to-${colorClass}-100/50 border-${colorClass}-200/50`
+          : 'bg-gradient-to-r from-slate-50 to-slate-100/50 border-slate-200/50'
+      }`}>
+        <div className="flex justify-between items-center">
+          <div className="flex items-center gap-2">
+            {icon}
+            <span className="font-medium text-slate-700 text-sm">{label}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleToggle}
+              disabled={isSaving}
+              className={`px-3 py-1 rounded-md text-sm font-semibold shadow-sm flex items-center gap-1.5 transition-colors disabled:opacity-50 ${
+                hasValue && isActive
+                  ? 'bg-white text-emerald-700 hover:bg-emerald-50'
+                  : hasValue
+                  ? 'bg-white text-slate-600 hover:bg-slate-50'
+                  : 'bg-white text-slate-400 hover:bg-slate-50'
+              }`}
+            >
+              {isSaving ? (
+                <svg className="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"/>
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/>
+                </svg>
+              ) : hasValue && isActive ? (
+                <>
+                  <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20">
+                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd"/>
+                  </svg>
+                  Yes
+                </>
+              ) : hasValue ? (
+                <>
+                  <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20">
+                    <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd"/>
+                  </svg>
+                  No
+                </>
+              ) : (
+                'Not detected'
+              )}
+            </button>
+            {isSuccess && (
+              <div className="text-emerald-600 animate-in fade-in">
+                <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                  <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd"/>
+                </svg>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  };
 
   return (
     <div className="fixed left-1/2 top-20 -translate-x-1/2 z-50 w-96 max-w-[calc(100vw-2rem)] bg-white rounded-xl shadow-2xl border border-slate-200 overflow-hidden animate-in fade-in slide-in-from-top-4 duration-200">
@@ -39,113 +327,149 @@ const FragmentMetadata: React.FC<FragmentMetadataProps> = ({ fragment, onClose }
       </div>
 
       {/* Content */}
-      <div className="p-5">
-        {metadata ? (
-          <div className="space-y-3">
-            {/* Line Count */}
-            {metadata.lineCount !== undefined && (
-              <div className="flex justify-between items-center p-3 bg-gradient-to-r from-blue-50 to-blue-100/50 rounded-lg border border-blue-200/50">
-                <div className="flex items-center gap-2">
-                  <svg className="w-4 h-4 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
-                  </svg>
-                  <span className="font-medium text-slate-700 text-sm">Line Count</span>
-                </div>
-                <span className="text-slate-900 bg-white px-3 py-1 rounded-md text-sm font-semibold shadow-sm">
-                  {metadata.lineCount}
-                </span>
-              </div>
-            )}
+      <div className="p-5 max-h-[calc(100vh-16rem)] overflow-y-auto">
+        <div className="space-y-3">
+          {/* Line Count */}
+          {renderEditableField(
+            'Line Count',
+            <svg className="w-4 h-4 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+            </svg>,
+            'lineCount',
+            'line_count',
+            metadata?.lineCount,
+            metadata?.lineCount !== undefined ? String(metadata.lineCount) : 'Not detected',
+            'number',
+            'blue',
+            metadata?.lineCount === undefined
+          )}
 
-            {/* Script */}
-            {metadata.script && (
-              <div className="flex justify-between items-center p-3 bg-gradient-to-r from-purple-50 to-purple-100/50 rounded-lg border border-purple-200/50">
-                <div className="flex items-center gap-2">
-                  <svg className="w-4 h-4 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129" />
-                  </svg>
-                  <span className="font-medium text-slate-700 text-sm">Script Type</span>
-                </div>
-                <span className="text-slate-900 bg-white px-3 py-1 rounded-md text-sm font-semibold shadow-sm">
-                  {metadata.script}
-                </span>
-              </div>
-            )}
+          {/* Script Type */}
+          {renderEditableField(
+            'Script Type',
+            <svg className="w-4 h-4 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129" />
+            </svg>,
+            'script',
+            'script_type',
+            metadata?.script,
+            metadata?.script ?? 'Not detected',
+            'text',
+            'purple',
+            metadata?.script === undefined
+          )}
 
-            {/* Edge Piece */}
-            {metadata.isEdgePiece !== undefined && (
-              <div className={`flex justify-between items-center p-3 rounded-lg border ${
-                metadata.isEdgePiece
-                  ? 'bg-gradient-to-r from-emerald-50 to-emerald-100/50 border-emerald-200/50'
-                  : 'bg-gradient-to-r from-slate-50 to-slate-100/50 border-slate-200/50'
-              }`}>
-                <div className="flex items-center gap-2">
-                  <svg className={`w-4 h-4 ${metadata.isEdgePiece ? 'text-emerald-600' : 'text-slate-500'}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
-                  </svg>
-                  <span className="font-medium text-slate-700 text-sm">Edge Piece</span>
-                </div>
-                <span className={`px-3 py-1 rounded-md text-sm font-semibold shadow-sm flex items-center gap-1.5 ${
-                  metadata.isEdgePiece
-                    ? 'bg-white text-emerald-700'
-                    : 'bg-white text-slate-600'
-                }`}>
-                  {metadata.isEdgePiece ? (
-                    <>
-                      <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20">
-                        <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd"/>
-                      </svg>
-                      Yes
-                    </>
-                  ) : (
-                    <>
-                      <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20">
-                        <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd"/>
-                      </svg>
-                      No
-                    </>
-                  )}
-                </span>
-              </div>
-            )}
+          {/* Edge Piece */}
+          {renderToggleField(
+            'Edge Piece',
+            <svg className={`w-4 h-4 ${metadata?.isEdgePiece ? 'text-emerald-600' : 'text-slate-400'}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+            </svg>,
+            'isEdgePiece',
+            'edge_piece',
+            metadata?.isEdgePiece,
+            'emerald'
+          )}
 
-            {/* Scale Information */}
-            {metadata.scale && (
-              <div className="flex justify-between items-center p-3 bg-gradient-to-r from-amber-50 to-amber-100/50 rounded-lg border border-amber-200/50">
+          {/* Top Edge */}
+          {renderToggleField(
+            'Top Edge',
+            <svg className={`w-4 h-4 ${metadata?.hasTopEdge ? 'text-emerald-600' : 'text-slate-400'}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 10l7-7m0 0l7 7m-7-7v18" />
+            </svg>,
+            'hasTopEdge',
+            'has_top_edge',
+            metadata?.hasTopEdge,
+            'emerald'
+          )}
+
+          {/* Bottom Edge */}
+          {renderToggleField(
+            'Bottom Edge',
+            <svg className={`w-4 h-4 ${metadata?.hasBottomEdge ? 'text-emerald-600' : 'text-slate-400'}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 14l-7 7m0 0l-7-7m7 7V3" />
+            </svg>,
+            'hasBottomEdge',
+            'has_bottom_edge',
+            metadata?.hasBottomEdge,
+            'emerald'
+          )}
+
+          {/* Scale Information */}
+          {metadata?.scale ? (
+            <div className="p-3 bg-gradient-to-r from-amber-50 to-amber-100/50 rounded-lg border border-amber-200/50">
+              <div className="flex justify-between items-start mb-2">
                 <div className="flex items-center gap-2">
                   <svg className="w-4 h-4 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3" />
                   </svg>
-                  <span className="font-medium text-slate-700 text-sm">Scale</span>
+                  <span className="font-medium text-slate-700 text-sm">Scale Information</span>
                 </div>
-                <div className="flex flex-col items-end">
-                  <span className="text-slate-900 bg-white px-3 py-1 rounded-md text-sm font-semibold shadow-sm">
-                    {metadata.scale.pixelsPerUnit.toFixed(1)} px/{metadata.scale.unit}
+                <span className={`text-xs px-2 py-0.5 rounded ${
+                  metadata.scale.detectionStatus === 'success' ? 'bg-emerald-100 text-emerald-700' : 'bg-red-100 text-red-700'
+                }`}>
+                  {metadata.scale.detectionStatus === 'success' ? 'Auto-detected' : 'Detection failed'}
+                </span>
+              </div>
+              {renderEditableField(
+                'Pixels per Unit',
+                <span className="text-xs text-slate-500">Value:</span>,
+                'pixelsPerUnit',
+                'pixels_per_unit',
+                metadata.scale.pixelsPerUnit,
+                `${metadata.scale.pixelsPerUnit.toFixed(1)} px/${metadata.scale.unit}`,
+                'number',
+                'amber'
+              )}
+            </div>
+          ) : (
+            <div className="p-3 bg-slate-50 rounded-lg border border-slate-200">
+              <div className="flex justify-between items-center">
+                <div className="flex items-center gap-2">
+                  <svg className="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3" />
+                  </svg>
+                  <span className="font-medium text-slate-700 text-sm">Scale Information</span>
+                </div>
+                <span className="text-slate-400 text-sm">No ruler detected</span>
+              </div>
+            </div>
+          )}
+
+          {/* Segmentation Status */}
+          {fragment.hasSegmentation ? (
+            <div className="p-3 bg-gradient-to-r from-indigo-50 to-indigo-100/50 rounded-lg border border-indigo-200/50">
+              <div className="flex justify-between items-center">
+                <div className="flex items-center gap-2">
+                  <svg className="w-4 h-4 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 5a1 1 0 011-1h4a1 1 0 011 1v7a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM14 5a1 1 0 011-1h4a1 1 0 011 1v7a1 1 0 01-1 1h-4a1 1 0 01-1-1V5zM4 16a1 1 0 011-1h4a1 1 0 011 1v3a1 1 0 01-1 1H5a1 1 0 01-1-1v-3zM14 16a1 1 0 011-1h4a1 1 0 011 1v3a1 1 0 01-1 1h-4a1 1 0 01-1-1v-3z" />
+                  </svg>
+                  <span className="font-medium text-slate-700 text-sm">Segmentation</span>
+                </div>
+                <div className="flex items-center gap-1.5">
+                  <span className="text-indigo-700 bg-white px-3 py-1 rounded-md text-sm font-semibold shadow-sm">
+                    Segmented
                   </span>
-                  <span className={`text-xs mt-1 ${
-                    metadata.scale.detectionStatus === 'success' ? 'text-emerald-600' : 'text-red-500'
-                  }`}>
-                    {metadata.scale.detectionStatus === 'success' ? 'Auto-detected' : 'Detection failed'}
-                  </span>
+                  <svg className="w-3.5 h-3.5 text-emerald-600" fill="currentColor" viewBox="0 0 20 20">
+                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd"/>
+                  </svg>
                 </div>
               </div>
-            )}
-          </div>
-        ) : (
-          <div className="text-center py-10">
-            <div className="bg-slate-100 rounded-full w-16 h-16 flex items-center justify-center mx-auto mb-3">
-              <svg className="w-8 h-8 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-              </svg>
             </div>
-            <p className="text-slate-600 text-sm font-medium mb-1">
-              No metadata available
-            </p>
-            <p className="text-slate-400 text-xs">
-              Metadata will be populated by ML models
-            </p>
-          </div>
-        )}
+          ) : (
+            <div className="p-3 bg-slate-50 rounded-lg border border-slate-200">
+              <div className="flex justify-between items-center">
+                <div className="flex items-center gap-2">
+                  <svg className="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 5a1 1 0 011-1h4a1 1 0 011 1v7a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM14 5a1 1 0 011-1h4a1 1 0 011 1v7a1 1 0 01-1 1h-4a1 1 0 01-1-1V5zM4 16a1 1 0 011-1h4a1 1 0 011 1v3a1 1 0 01-1 1H5a1 1 0 01-1-1v-3zM14 16a1 1 0 011-1h4a1 1 0 011 1v3a1 1 0 01-1 1h-4a1 1 0 01-1-1v-3z" />
+                  </svg>
+                  <span className="font-medium text-slate-700 text-sm">Segmentation</span>
+                </div>
+                <span className="text-slate-400 text-sm">Not segmented</span>
+              </div>
+            </div>
+          )}
+        </div>
       </div>
 
       {/* Footer note */}
@@ -153,7 +477,7 @@ const FragmentMetadata: React.FC<FragmentMetadataProps> = ({ fragment, onClose }
         <svg className="w-3.5 h-3.5 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
         </svg>
-        <span>Click outside or press ESC to close</span>
+        <span>Click field values to edit • Press ESC to close</span>
       </div>
     </div>
   );

--- a/src/web/web-canvas/src/components/Sidebar.tsx
+++ b/src/web/web-canvas/src/components/Sidebar.tsx
@@ -17,6 +17,7 @@ interface SidebarProps {
   searchQuery?: string | null;
   onClearSearch?: () => void;
   onSidebarSearch?: (query: string) => void;
+  onFragmentUpdate?: () => void; // Callback to refresh fragments after metadata edit
 }
 
 const Sidebar: React.FC<SidebarProps> = ({
@@ -33,6 +34,7 @@ const Sidebar: React.FC<SidebarProps> = ({
   searchQuery = null,
   onClearSearch,
   onSidebarSearch,
+  onFragmentUpdate,
 }) => {
   const [selectedFragment, setSelectedFragment] = useState<ManuscriptFragment | null>(null);
   const [isResizing, setIsResizing] = useState(false);
@@ -390,6 +392,7 @@ const Sidebar: React.FC<SidebarProps> = ({
           <FragmentMetadata
             fragment={selectedFragment}
             onClose={handleCloseMetadata}
+            onUpdate={onFragmentUpdate}
           />
         </>
       )}

--- a/src/web/web-canvas/src/components/Toolbar.tsx
+++ b/src/web/web-canvas/src/components/Toolbar.tsx
@@ -15,9 +15,10 @@ interface ToolbarProps {
   isFilterPanelOpen: boolean;
   onToggleFilters: () => void;
   hasActiveFilters: boolean;
-  // Segmentation toggle
-  showSegmented: boolean;
-  onToggleSegmented: () => void;
+  // Per-fragment segmentation toggle (only shows for single selection)
+  selectedFragmentHasSegmentation?: boolean;
+  selectedFragmentShowSegmented?: boolean;
+  onToggleSelectedFragmentSegmentation?: () => void;
   // Session management props
   projectName?: string;
   saveStatus?: 'saved' | 'saving' | 'unsaved';
@@ -37,8 +38,9 @@ const Toolbar: React.FC<ToolbarProps> = ({
   isFilterPanelOpen,
   onToggleFilters,
   hasActiveFilters,
-  showSegmented,
-  onToggleSegmented,
+  selectedFragmentHasSegmentation,
+  selectedFragmentShowSegmented,
+  onToggleSelectedFragmentSegmentation,
   projectName,
   saveStatus = 'saved',
 }) => {
@@ -220,6 +222,49 @@ const Toolbar: React.FC<ToolbarProps> = ({
               <span className="text-sm font-bold">Unlock</span>
             </button>
 
+            {/* Segmentation toggle - only show for single selection with segmentation data */}
+            {selectedCount === 1 && selectedFragmentHasSegmentation && onToggleSelectedFragmentSegmentation && (
+              <button
+                onClick={onToggleSelectedFragmentSegmentation}
+                className="px-4 py-2.5 text-white rounded-lg transition-all duration-200 flex items-center gap-2 shadow-lg hover:shadow-xl hover:scale-105 font-body"
+                style={{
+                  background: selectedFragmentShowSegmented
+                    ? 'linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%)'
+                    : 'linear-gradient(135deg, #6b7280 0%, #4b5563 100%)'
+                }}
+                onMouseEnter={(e) => {
+                  if (selectedFragmentShowSegmented) {
+                    e.currentTarget.style.background = 'linear-gradient(135deg, #a78bfa 0%, #8b5cf6 100%)';
+                  } else {
+                    e.currentTarget.style.background = 'linear-gradient(135deg, #9ca3af 0%, #6b7280 100%)';
+                  }
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.background = selectedFragmentShowSegmented
+                    ? 'linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%)'
+                    : 'linear-gradient(135deg, #6b7280 0%, #4b5563 100%)';
+                }}
+                title={selectedFragmentShowSegmented ? "Show original image" : "Show segmented image (transparent background)"}
+              >
+                <svg
+                  className="w-5 h-5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  strokeWidth={2.5}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                  />
+                </svg>
+                <span className="text-sm font-bold">
+                  {selectedFragmentShowSegmented ? 'Segmented' : 'Original'}
+                </span>
+              </button>
+            )}
+
             <button
               onClick={onDeleteSelected}
               className="px-4 py-2.5 text-white rounded-lg transition-all duration-200 flex items-center gap-2 shadow-lg hover:shadow-xl hover:scale-105 font-body"
@@ -322,43 +367,6 @@ const Toolbar: React.FC<ToolbarProps> = ({
             />
           </svg>
           <span className="text-sm font-semibold">Grid</span>
-        </button>
-
-        <button
-          onClick={onToggleSegmented}
-          className="px-3.5 py-2 rounded-lg transition-all duration-200 flex items-center gap-2 shadow-md hover:shadow-lg font-body"
-          style={{
-            background: showSegmented ? 'linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%)' : 'rgba(68, 64, 60, 0.8)',
-            color: showSegmented ? '#ffffff' : '#d6d3d1'
-          }}
-          onMouseEnter={(e) => {
-            if (showSegmented) {
-              e.currentTarget.style.background = 'linear-gradient(135deg, #a78bfa 0%, #8b5cf6 100%)';
-            } else {
-              e.currentTarget.style.background = 'rgba(87, 83, 78, 0.9)';
-              e.currentTarget.style.color = '#fafaf9';
-            }
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.background = showSegmented ? 'linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%)' : 'rgba(68, 64, 60, 0.8)';
-            e.currentTarget.style.color = showSegmented ? '#ffffff' : '#d6d3d1';
-          }}
-          title={showSegmented ? "Show original images" : "Show segmented images (transparent background)"}
-        >
-          <svg
-            className="w-4 h-4"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            strokeWidth={2}
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
-            />
-          </svg>
-          <span className="text-sm font-semibold">Segmented</span>
         </button>
 
         <button

--- a/src/web/web-canvas/src/components/VirtualizedFragmentList.tsx
+++ b/src/web/web-canvas/src/components/VirtualizedFragmentList.tsx
@@ -64,15 +64,6 @@ const FragmentRow = ({ index, style, data }: ListChildComponentProps<FragmentRow
         </div>
         {/* Badges container */}
         <div className="absolute top-2 right-2 flex flex-col gap-1">
-          {/* Segmentation indicator badge */}
-          {fragment.hasSegmentation && (
-            <div className="bg-gradient-to-br from-violet-500 to-violet-600 text-white rounded-md px-2 py-1 flex items-center gap-1.5 shadow-md ring-2 ring-white">
-              <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
-              </svg>
-              <span className="text-[10px] font-semibold uppercase tracking-wide">Segmented</span>
-            </div>
-          )}
           {/* Metadata indicator badge */}
           {fragment.metadata && (
             <div className="bg-gradient-to-br from-emerald-500 to-emerald-600 text-white rounded-md px-2 py-1 flex items-center gap-1.5 shadow-md ring-2 ring-white">

--- a/src/web/web-canvas/src/services/fragment-service.ts
+++ b/src/web/web-canvas/src/services/fragment-service.ts
@@ -28,7 +28,9 @@ export function mapToManuscriptFragment(record: FragmentRecord): ManuscriptFragm
     metadata: {
       lineCount: record.line_count ?? undefined,
       script: record.script_type ?? undefined,
-      isEdgePiece: record.edge_piece === 1,
+      isEdgePiece: record.edge_piece === 1 ? true : record.edge_piece === 0 ? false : undefined,
+      hasTopEdge: record.has_top_edge === 1 ? true : undefined,
+      hasBottomEdge: record.has_bottom_edge === 1 ? true : undefined,
       // Map scale data if available
       scale: record.scale_unit && record.pixels_per_unit ? {
         unit: record.scale_unit as 'cm' | 'mm',
@@ -115,6 +117,22 @@ export async function updateFragmentNotes(
   const response = await api.fragments.updateMetadata(fragmentId, { notes });
 
   return response.success;
+}
+
+/**
+ * Update fragment metadata
+ */
+export async function updateFragmentMetadata(
+  fragmentId: string,
+  metadata: Record<string, unknown>
+): Promise<{ success: boolean; error?: string }> {
+  if (!isElectron()) {
+    return { success: false, error: 'Not in Electron environment' };
+  }
+
+  const api = getElectronAPI();
+  const response = await api.fragments.updateMetadata(fragmentId, metadata);
+  return response;
 }
 
 /**

--- a/src/web/web-canvas/src/types/fragment.ts
+++ b/src/web/web-canvas/src/types/fragment.ts
@@ -11,12 +11,15 @@ export interface ManuscriptFragment {
     lineCount?: number;
     script?: string;
     isEdgePiece?: boolean;
+    hasTopEdge?: boolean;
+    hasBottomEdge?: boolean;
     // Scale information from ruler detection
     scale?: {
       unit: 'cm' | 'mm';  // Physical unit
       pixelsPerUnit: number;  // Pixels per unit in original image
       detectionStatus: 'success' | 'error';  // Detection result
     };
+    segmentationStatus?: string; // For displaying segmentation processing status
   };
 }
 
@@ -34,6 +37,7 @@ export interface CanvasFragment {
   scaleY: number;
   isLocked: boolean;
   isSelected: boolean;
+  showSegmented: boolean; // Per-fragment toggle for showing segmented version
 }
 
 export interface CanvasState {

--- a/src/web/web-canvas/src/utils/metadataValidation.ts
+++ b/src/web/web-canvas/src/utils/metadataValidation.ts
@@ -1,0 +1,64 @@
+/**
+ * Validation utilities for fragment metadata editing
+ */
+
+export interface ValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+export function validateLineCount(value: number): ValidationResult {
+  // Allow null/undefined to clear the field
+  if (value === null || value === undefined || value === '') {
+    return { valid: true };
+  }
+  const num = Number(value);
+  if (isNaN(num)) {
+    return { valid: false, error: 'Line count must be a number' };
+  }
+  if (!Number.isInteger(num)) {
+    return { valid: false, error: 'Line count must be a whole number' };
+  }
+  if (num < 0) {
+    return { valid: false, error: 'Line count cannot be negative' };
+  }
+  if (num > 100) {
+    return { valid: false, error: 'Line count must be 100 or less' };
+  }
+  return { valid: true };
+}
+
+export function validatePixelsPerUnit(value: number): ValidationResult {
+  if (isNaN(value)) {
+    return { valid: false, error: 'Must be a valid number' };
+  }
+  if (value <= 0) {
+    return { valid: false, error: 'Pixels per unit must be positive' };
+  }
+  if (value > 10000) {
+    return { valid: false, error: 'Value seems too large' };
+  }
+  return { valid: true };
+}
+
+export function validateScriptType(value: string): ValidationResult {
+  // Allow empty/undefined to clear the field
+  if (value === undefined || value === null) {
+    return { valid: true };
+  }
+  const trimmed = String(value).trim();
+  if (trimmed.length === 0) {
+    return { valid: true }; // Allow clearing the field
+  }
+  if (trimmed.length > 100) {
+    return { valid: false, error: 'Script type is too long' };
+  }
+  return { valid: true };
+}
+
+export function validateScaleUnit(value: string): ValidationResult {
+  if (!['cm', 'mm'].includes(value)) {
+    return { valid: false, error: 'Scale unit must be "cm" or "mm"' };
+  }
+  return { valid: true };
+}


### PR DESCRIPTION
   This commit adds the ability to view fragment metadata by double-clicking
   fragments on the canvas, along with several related improvements to fragment
   management and UI consistency.

   Key Features:
   - Double-click fragments on canvas to display metadata modal
   - Metadata modal works for both newly-added and loaded session fragments
   - Fallback to database fetch when fragment not in loaded list

   Additional Improvements:
   - Enhanced metadata validation and editing
   - Improved sidebar search and filtering
   - Better fragment service database integration
   - UI/UX consistency improvements across components

   Technical Changes:
   - Canvas.tsx: Add onDblClick/onDblTap handlers for FragmentImage
   - CanvasPage.tsx: Add metadata modal state and async fragment fetching
   - FragmentMetadata.tsx: Enhanced validation and user feedback
   - fragment-service.ts: Improved database query handling
   - Added metadataValidation.ts utility for form validation