### PR TITLE
Fix syntax error in database.py migration method

### DIFF
--- a/src/ml_pipeline/core/database.py
+++ b/src/ml_pipeline/core/database.py
@@ -90,11 +90,6 @@ class DatabaseManager:
             self.conn.commit()
             self.logger.info("Migration completed successfully")
 
-        except sqlite3.Error as e:
-            self.conn.rollback()
-            self.logger.error(f"Migration failed: {e}")
-            raise
-
     def get_fragments(
         self,
         limit: Optional[int] = None,


### PR DESCRIPTION
Remove orphaned except block without corresponding try statement that was causing SyntaxError when importing the ml_pipeline module.