### PR TITLE
Fix circle detection model path in pipeline config

### DIFF
--- a/src/ml_pipeline/config.yaml
+++ b/src/ml_pipeline/config.yaml
@@ -47,7 +47,7 @@ processors:
   
   circledetection:
     enabled: true
-    model_path: "../classification/circle_class/best.pt"
+    model_path: "../models/circle-classification/best.pt"
     config:
       confidence_threshold: 0.25
       model_version: "1.0"


### PR DESCRIPTION
The circle detection processor was configured with an incorrect model path pointing to '../classification/circle_class/best.pt', which does not exist. Updated to the correct path '../models/circle-classification/best.pt' where the trained circle classification model is actually located.

This fixes the pipeline error: "No such file or directory: '/Users/.../classification/circle_class/best.pt'"