### PR TITLE
Add circle classification to front-end filtering and metadata

### DIFF
--- a/src/web/web-canvas/electron/main/ipc/handlers.ts
+++ b/src/web/web-canvas/electron/main/ipc/handlers.ts
@@ -15,6 +15,7 @@ interface FragmentFilters {
   lineCountMax?: number;
   scripts?: string[];
   isEdgePiece?: boolean | null;
+  hasCircle?: boolean | null;
   search?: string;
   limit?: number;
   offset?: number;
@@ -73,6 +74,11 @@ export function registerIpcHandlers(): void {
     if (filters?.isEdgePiece !== undefined && filters.isEdgePiece !== null) {
       query += ' AND edge_piece = ?';
       params.push(filters.isEdgePiece ? 1 : 0);
+    }
+
+    if (filters?.hasCircle !== undefined && filters.hasCircle !== null) {
+      query += ' AND has_circle = ?';
+      params.push(filters.hasCircle ? 1 : 0);
     }
 
     if (filters?.search) {
@@ -134,6 +140,11 @@ export function registerIpcHandlers(): void {
       params.push(filters.isEdgePiece ? 1 : 0);
     }
 
+    if (filters?.hasCircle !== undefined && filters.hasCircle !== null) {
+      query += ' AND has_circle = ?';
+      params.push(filters.hasCircle ? 1 : 0);
+    }
+
     if (filters?.search) {
       query += ' AND fragment_id LIKE ?';
       params.push(`%${filters.search}%`);
@@ -170,6 +181,7 @@ export function registerIpcHandlers(): void {
       'edge_piece',
       'has_top_edge',
       'has_bottom_edge',
+      'has_circle',
       'line_count',
       'script_type',
       'scale_unit',

--- a/src/web/web-canvas/src/components/FilterPanel.tsx
+++ b/src/web/web-canvas/src/components/FilterPanel.tsx
@@ -49,6 +49,10 @@ const FilterPanel: React.FC<FilterPanelProps> = ({
     setLocalFilters({ ...localFilters, isEdgePiece: value });
   };
 
+  const handleCircleChange = (value: boolean | null) => {
+    setLocalFilters({ ...localFilters, hasCircle: value });
+  };
+
   const handleApply = () => {
     onFiltersChange(localFilters);
   };
@@ -62,7 +66,8 @@ const FilterPanel: React.FC<FilterPanelProps> = ({
     localFilters.lineCountMin !== undefined ||
     localFilters.lineCountMax !== undefined ||
     localFilters.scripts.length > 0 ||
-    localFilters.isEdgePiece !== null;
+    localFilters.isEdgePiece !== null ||
+    localFilters.hasCircle !== null;
 
   const handleMouseDown = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -194,6 +199,12 @@ const FilterPanel: React.FC<FilterPanelProps> = ({
                       )}
                       {filters.isEdgePiece === false && (
                         <div>• Non-edge pieces only</div>
+                      )}
+                      {filters.hasCircle === true && (
+                        <div>• Has circle only</div>
+                      )}
+                      {filters.hasCircle === false && (
+                        <div>• No circle only</div>
                       )}
                     </div>
                   </div>
@@ -339,6 +350,55 @@ const FilterPanel: React.FC<FilterPanelProps> = ({
                     name="edgePiece"
                     checked={localFilters.isEdgePiece === false}
                     onChange={() => handleEdgePieceChange(false)}
+                    className="w-4 h-4 text-slate-600 border-slate-300 focus:ring-2 focus:ring-slate-500 cursor-pointer"
+                  />
+                  <span className="text-sm text-slate-700 font-medium">No</span>
+                </label>
+              </div>
+            </div>
+
+            {/* Circle Detection Filter */}
+            <div className={`bg-white rounded-lg p-4 shadow-sm border-2 transition-all ${
+              localFilters.hasCircle !== null
+                ? 'border-cyan-400 ring-2 ring-cyan-100'
+                : 'border-slate-200'
+            }`}>
+              <div className="flex items-center gap-2 mb-3">
+                <svg className="w-4 h-4 text-cyan-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <circle cx="12" cy="12" r="9" strokeWidth={2} />
+                </svg>
+                <h3 className="font-semibold text-slate-800 text-sm">Has Circle</h3>
+                {localFilters.hasCircle !== null && (
+                  <span className="ml-auto text-xs bg-cyan-100 text-cyan-700 px-2 py-0.5 rounded-full font-semibold">Active</span>
+                )}
+              </div>
+              <div className="space-y-2">
+                <label className="flex items-center gap-3 p-2 rounded-md hover:bg-slate-50 cursor-pointer transition-colors">
+                  <input
+                    type="radio"
+                    name="hasCircle"
+                    checked={localFilters.hasCircle === null}
+                    onChange={() => handleCircleChange(null)}
+                    className="w-4 h-4 text-slate-600 border-slate-300 focus:ring-2 focus:ring-slate-500 cursor-pointer"
+                  />
+                  <span className="text-sm text-slate-700 font-medium">Don't care</span>
+                </label>
+                <label className="flex items-center gap-3 p-2 rounded-md hover:bg-slate-50 cursor-pointer transition-colors">
+                  <input
+                    type="radio"
+                    name="hasCircle"
+                    checked={localFilters.hasCircle === true}
+                    onChange={() => handleCircleChange(true)}
+                    className="w-4 h-4 text-cyan-600 border-slate-300 focus:ring-2 focus:ring-cyan-500 cursor-pointer"
+                  />
+                  <span className="text-sm text-slate-700 font-medium">Yes</span>
+                </label>
+                <label className="flex items-center gap-3 p-2 rounded-md hover:bg-slate-50 cursor-pointer transition-colors">
+                  <input
+                    type="radio"
+                    name="hasCircle"
+                    checked={localFilters.hasCircle === false}
+                    onChange={() => handleCircleChange(false)}
                     className="w-4 h-4 text-slate-600 border-slate-300 focus:ring-2 focus:ring-slate-500 cursor-pointer"
                   />
                   <span className="text-sm text-slate-700 font-medium">No</span>

--- a/src/web/web-canvas/src/components/FragmentMetadata.tsx
+++ b/src/web/web-canvas/src/components/FragmentMetadata.tsx
@@ -255,7 +255,9 @@ const FragmentMetadata: React.FC<FragmentMetadataProps> = ({ fragment: initialFr
               disabled={isSaving}
               className={`px-3 py-1 rounded-md text-sm font-semibold shadow-sm flex items-center gap-1.5 transition-colors disabled:opacity-50 ${
                 hasValue && isActive
-                  ? 'bg-white text-emerald-700 hover:bg-emerald-50'
+                  ? colorClass === 'cyan'
+                    ? 'bg-white text-cyan-700 hover:bg-cyan-50'
+                    : 'bg-white text-emerald-700 hover:bg-emerald-50'
                   : hasValue
                   ? 'bg-white text-slate-600 hover:bg-slate-50'
                   : 'bg-white text-slate-400 hover:bg-slate-50'
@@ -393,6 +395,18 @@ const FragmentMetadata: React.FC<FragmentMetadataProps> = ({ fragment: initialFr
             'has_bottom_edge',
             metadata?.hasBottomEdge,
             'emerald'
+          )}
+
+          {/* Circle Detection */}
+          {renderToggleField(
+            'Has Circle',
+            <svg className={`w-4 h-4 ${metadata?.hasCircle ? 'text-cyan-600' : 'text-slate-400'}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <circle cx="12" cy="12" r="9" strokeWidth={2} />
+            </svg>,
+            'hasCircle',
+            'has_circle',
+            metadata?.hasCircle,
+            'cyan'
           )}
 
           {/* Scale Information */}

--- a/src/web/web-canvas/src/pages/CanvasPage.tsx
+++ b/src/web/web-canvas/src/pages/CanvasPage.tsx
@@ -76,6 +76,7 @@ function CanvasPage() {
         lineCountMax?: number;
         scripts?: string[];
         isEdgePiece?: boolean | null;
+        hasCircle?: boolean | null;
         search?: string;
         limit?: number;
         offset?: number;
@@ -95,6 +96,9 @@ function CanvasPage() {
       }
       if (filters.isEdgePiece !== null) {
         apiFilters.isEdgePiece = filters.isEdgePiece;
+      }
+      if (filters.hasCircle !== null) {
+        apiFilters.hasCircle = filters.hasCircle;
       }
       if (filters.search) {
         apiFilters.search = filters.search;
@@ -135,6 +139,7 @@ function CanvasPage() {
         lineCountMax?: number;
         scripts?: string[];
         isEdgePiece?: boolean | null;
+        hasCircle?: boolean | null;
         search?: string;
         limit?: number;
         offset?: number;
@@ -154,6 +159,9 @@ function CanvasPage() {
       }
       if (filters.isEdgePiece !== null) {
         apiFilters.isEdgePiece = filters.isEdgePiece;
+      }
+      if (filters.hasCircle !== null) {
+        apiFilters.hasCircle = filters.hasCircle;
       }
 
       const moreFragments = await getAllFragments(apiFilters);

--- a/src/web/web-canvas/src/services/electron-api.ts
+++ b/src/web/web-canvas/src/services/electron-api.ts
@@ -10,6 +10,7 @@ export interface FragmentFilters {
   lineCountMax?: number;
   scripts?: string[];
   isEdgePiece?: boolean | null;
+  hasCircle?: boolean | null;
   search?: string;
   limit?: number;
   offset?: number;
@@ -33,6 +34,8 @@ export interface FragmentRecord {
   pixels_per_unit: number | null;
   scale_detection_status: string | null;
   scale_model_version: string | null;
+  // Circle detection field
+  has_circle: number | null;
 }
 
 export interface CanvasFragmentData {

--- a/src/web/web-canvas/src/services/fragment-service.ts
+++ b/src/web/web-canvas/src/services/fragment-service.ts
@@ -31,6 +31,7 @@ export function mapToManuscriptFragment(record: FragmentRecord): ManuscriptFragm
       isEdgePiece: record.edge_piece === 1 ? true : record.edge_piece === 0 ? false : undefined,
       hasTopEdge: record.has_top_edge === 1 ? true : undefined,
       hasBottomEdge: record.has_bottom_edge === 1 ? true : undefined,
+      hasCircle: record.has_circle === 1 ? true : record.has_circle === 0 ? false : undefined,
       // Map scale data if available
       scale: record.scale_unit && record.pixels_per_unit ? {
         unit: record.scale_unit as 'cm' | 'mm',

--- a/src/web/web-canvas/src/types/filters.ts
+++ b/src/web/web-canvas/src/types/filters.ts
@@ -3,6 +3,7 @@ export interface FragmentFilters {
   lineCountMax?: number;
   scripts: string[]; // Empty array = all scripts
   isEdgePiece?: boolean | null; // null = don't care
+  hasCircle?: boolean | null; // null = don't care
   search?: string; // Fragment ID search query
 }
 
@@ -11,5 +12,6 @@ export const DEFAULT_FILTERS: FragmentFilters = {
   lineCountMax: undefined,
   scripts: [],
   isEdgePiece: null,
+  hasCircle: null,
   search: undefined,
 };

--- a/src/web/web-canvas/src/types/fragment.ts
+++ b/src/web/web-canvas/src/types/fragment.ts
@@ -13,6 +13,7 @@ export interface ManuscriptFragment {
     isEdgePiece?: boolean;
     hasTopEdge?: boolean;
     hasBottomEdge?: boolean;
+    hasCircle?: boolean;  // Circle classification from ML model
     // Scale information from ruler detection
     scale?: {
       unit: 'cm' | 'mm';  // Physical unit


### PR DESCRIPTION
- Add hasCircle to TypeScript types and database interfaces
- Add circle filter UI to FilterPanel with cyan theme
- Add circle toggle field to FragmentMetadata component
- Update IPC handlers to support circle filtering and updates
- Map has_circle field from database to UI in fragment service
- Include hasCircle filter in CanvasPage API calls