### PR TITLE
Fix script type display and database mapping

### DIFF
--- a/src/web/web-canvas/src/components/FragmentMetadata.tsx
+++ b/src/web/web-canvas/src/components/FragmentMetadata.tsx
@@ -7,7 +7,7 @@ import {
   validateScriptType,
   validateScaleUnit,
 } from '../utils/metadataValidation';
-import { SCRIPT_TYPES } from '../types/constants';
+import { SCRIPT_TYPES, getScriptTypeDB } from '../types/constants';
 
 interface FragmentMetadataProps {
   fragment: ManuscriptFragment;
@@ -73,8 +73,14 @@ const FragmentMetadata: React.FC<FragmentMetadataProps> = ({
     setSavingField(field);
     setFieldErrors({ ...fieldErrors, [field]: '' });
 
+    // Convert display value to database value for script type
+    let dbValue = value;
+    if (field === 'script') {
+      dbValue = getScriptTypeDB(value) || value;
+    }
+
     try {
-      const result = await updateFragmentMetadata(fragment.id, { [dbField]: value });
+      const result = await updateFragmentMetadata(fragment.id, { [dbField]: dbValue });
 
       if (result.success) {
         // Refetch the fragment to get updated data

--- a/src/web/web-canvas/src/pages/HomePage.tsx
+++ b/src/web/web-canvas/src/pages/HomePage.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getElectronAPISafe, Project } from '../services/electron-api';
-import { mapToManuscriptFragment } from '../services/fragment-service';
+import { mapToManuscriptFragment, getFragmentCount } from '../services/fragment-service';
 import { ManuscriptFragment } from '../types/fragment';
 
 const HomePage: React.FC = () => {
@@ -11,6 +11,7 @@ const HomePage: React.FC = () => {
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
   const [hoveredProject, setHoveredProject] = useState<number | null>(null);
+  const [fragmentCount, setFragmentCount] = useState<number>(0);
 
   // Rename state
   const [editingProjectId, setEditingProjectId] = useState<number | null>(null);
@@ -24,10 +25,20 @@ const HomePage: React.FC = () => {
   const [isLoadingAutocomplete, setIsLoadingAutocomplete] = useState(false);
   const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  // Load projects on mount
+  // Load projects and fragment count on mount
   useEffect(() => {
     loadProjects();
+    loadFragmentCount();
   }, []);
+
+  const loadFragmentCount = async () => {
+    try {
+      const count = await getFragmentCount();
+      setFragmentCount(count);
+    } catch (error) {
+      console.error('Failed to load fragment count:', error);
+    }
+  };
 
   // Debounced autocomplete search
   useEffect(() => {
@@ -675,7 +686,7 @@ const HomePage: React.FC = () => {
             borderColor: 'rgba(214, 211, 209, 0.4)'
           }}>
             <div className="text-3xl font-bold font-body" style={{ color: '#d97706' }}>
-              ∞
+              {fragmentCount.toLocaleString()}
             </div>
             <div className="text-xs font-semibold mt-1.5 font-body" style={{ color: '#57534e' }}>
               Fragments Available

--- a/src/web/web-canvas/src/services/fragment-service.ts
+++ b/src/web/web-canvas/src/services/fragment-service.ts
@@ -11,6 +11,7 @@ import {
   FragmentRecord,
   FragmentFilters as ApiFilters,
 } from './electron-api';
+import { getScriptTypeDisplay } from '../types/constants';
 
 // Re-export for convenience
 export type { ApiFilters as FragmentApiFilters };
@@ -27,7 +28,7 @@ export function mapToManuscriptFragment(record: FragmentRecord): ManuscriptFragm
     thumbnailPath: `electron-image://${record.image_path}`,
     metadata: {
       lineCount: record.line_count ?? undefined,
-      script: record.script_type ?? undefined,
+      script: getScriptTypeDisplay(record.script_type),
       isEdgePiece: record.edge_piece === 1 ? true : record.edge_piece === 0 ? false : undefined,
       hasTopEdge: record.has_top_edge === 1 ? true : record.has_top_edge === 0 ? false : undefined,
       hasBottomEdge: record.has_bottom_edge === 1 ? true : record.has_bottom_edge === 0 ? false : undefined,

--- a/src/web/web-canvas/src/types/constants.ts
+++ b/src/web/web-canvas/src/types/constants.ts
@@ -3,7 +3,18 @@
  */
 
 /**
- * Available Turkestan Brāhmī script types
+ * Model output values (stored in database without accents)
+ */
+export const MODEL_SCRIPT_TYPES = [
+  'Early South Turkestan Brahmi',
+  'North Turkestan Brahmi',
+  'North Turkestan Brahmi, type a',
+  'South Turkestan Brahmi',
+  'Turkestan Gupta Type',
+] as const;
+
+/**
+ * Display values with proper diacritics for UI
  */
 export const SCRIPT_TYPES = [
   'Early South Turkestan Brāhmī',
@@ -14,5 +25,49 @@ export const SCRIPT_TYPES = [
   'North Turkestan Brāhmī, type b',
   'Early Turkestan Brāhmī, alphabet r',
 ] as const;
+
+/**
+ * Mapping from model output (database values) to display values (with diacritics)
+ */
+export const SCRIPT_TYPE_DISPLAY_MAP: Record<string, string> = {
+  'Early South Turkestan Brahmi': 'Early South Turkestan Brāhmī',
+  'North Turkestan Brahmi': 'North Turkestan Brāhmī',
+  'North Turkestan Brahmi, type a': 'North Turkestan Brāhmī, type a',
+  'South Turkestan Brahmi': 'South Turkestan Brāhmī (main type)',
+  'Turkestan Gupta Type': 'Turkestan Gupta Type',
+  // Legacy/manual entries (keep for backwards compatibility)
+  'North Turkestan Brāhmī, type b': 'North Turkestan Brāhmī, type b',
+  'Early Turkestan Brāhmī, alphabet r': 'Early Turkestan Brāhmī, alphabet r',
+};
+
+/**
+ * Reverse mapping from display values to database values
+ */
+export const SCRIPT_TYPE_DB_MAP: Record<string, string> = {
+  'Early South Turkestan Brāhmī': 'Early South Turkestan Brahmi',
+  'North Turkestan Brāhmī': 'North Turkestan Brahmi',
+  'North Turkestan Brāhmī, type a': 'North Turkestan Brahmi, type a',
+  'South Turkestan Brāhmī (main type)': 'South Turkestan Brahmi',
+  'Turkestan Gupta Type': 'Turkestan Gupta Type',
+  // Legacy/manual entries
+  'North Turkestan Brāhmī, type b': 'North Turkestan Brāhmī, type b',
+  'Early Turkestan Brāhmī, alphabet r': 'Early Turkestan Brāhmī, alphabet r',
+};
+
+/**
+ * Convert database script type to display format
+ */
+export function getScriptTypeDisplay(dbValue: string | null | undefined): string | undefined {
+  if (!dbValue) return undefined;
+  return SCRIPT_TYPE_DISPLAY_MAP[dbValue] || dbValue;
+}
+
+/**
+ * Convert display script type to database format
+ */
+export function getScriptTypeDB(displayValue: string | null | undefined): string | undefined {
+  if (!displayValue) return undefined;
+  return SCRIPT_TYPE_DB_MAP[displayValue] || displayValue;
+}
 
 export type ScriptType = typeof SCRIPT_TYPES[number];


### PR DESCRIPTION
Fixes bug where script type names with diacritics were not properly mapped between database values and display values.

Changes:
- Add SCRIPT_TYPE_DISPLAY_MAP for converting database values to UI display
- Add SCRIPT_TYPE_DB_MAP for converting UI values to database values
- Add getScriptTypeDisplay() and getScriptTypeDB() helper functions
- Update FragmentMetadata to convert display values to DB values on save
- Update fragment-service to convert DB values to display values on load
- Add fragment count display to HomePage (replaces infinity symbol)

Database values (no diacritics):
- "Early South Turkestan Brahmi"
- "North Turkestan Brahmi"
- "South Turkestan Brahmi"

Display values (with diacritics):
- "Early South Turkestan Brāhmī"
- "North Turkestan Brāhmī"
- "South Turkestan Brāhmī (main type)"

This ensures consistency between ML pipeline output and user-facing UI.