### PR TITLE
Fix segmentation renderer using wrong contour (#189)

### DIFF
--- a/src/web/web-canvas/src/utils/segmentation-cache.ts
+++ b/src/web/web-canvas/src/utils/segmentation-cache.ts
@@ -9,7 +9,7 @@ import { createSegmentedImage, hasValidSegmentation } from './segmentation-rende
 
 const DB_NAME = 'segmentation-cache';
 const STORE_NAME = 'segmented-images';
-const DB_VERSION = 1;
+const DB_VERSION = 2; // Bumped to invalidate stale cache: renderer now uses largest contour
 
 interface CacheEntry {
   fragmentId: string;

--- a/src/web/web-canvas/src/utils/segmentation-renderer.ts
+++ b/src/web/web-canvas/src/utils/segmentation-renderer.ts
@@ -37,8 +37,11 @@ export async function createSegmentedImage(
           return;
         }
 
-        // Use the first (and typically only) contour
-        const contour = coordsData.contours[0];
+        // Use the largest contour (most points = largest area = main fragment body)
+        // YOLO often produces multiple contours where smaller ones are noise artifacts
+        const contour = coordsData.contours.reduce((largest, current) =>
+          current.length > largest.length ? current : largest
+        );
 
         if (!Array.isArray(contour) || contour.length < 3) {
           reject(new Error('Invalid contour data: must have at least 3 points'));
@@ -98,13 +101,14 @@ export function hasValidSegmentation(segmentationCoordsJson: string | null): boo
 
   try {
     const coordsData: SegmentationCoords = JSON.parse(segmentationCoordsJson);
-    return (
-      coordsData.contours &&
-      Array.isArray(coordsData.contours) &&
-      coordsData.contours.length > 0 &&
-      Array.isArray(coordsData.contours[0]) &&
-      coordsData.contours[0].length >= 3
+    if (!coordsData.contours || !Array.isArray(coordsData.contours) || coordsData.contours.length === 0) {
+      return false;
+    }
+    // Check that at least one contour has enough points
+    const largestContour = coordsData.contours.reduce((largest, current) =>
+      current.length > largest.length ? current : largest
     );
+    return Array.isArray(largestContour) && largestContour.length >= 3;
   } catch {
     return false;
   }


### PR DESCRIPTION
YOLO produces multiple contours per fragment - smaller ones are noise artifacts (shadows, scan specks) while the main fragment body is the largest contour. The renderer was always picking contours[0] which is often a tiny noise polygon, causing fragments to appear nearly invisible when dropped on the canvas.

Fix: select the contour with the most points (largest area) instead of the first one. Also bumps the IndexedDB cache version to 2 to invalidate stale renders from the old logic.