### PR TITLE
UI polish: remove hint text, wider sidebar, auto-hide grid reference …

### DIFF
--- a/src/web/web-canvas/src/components/Canvas.tsx
+++ b/src/web/web-canvas/src/components/Canvas.tsx
@@ -167,6 +167,8 @@ const Canvas: React.FC<CanvasProps> = ({
   const isTransformingRef = useRef(false);
   const [showSplash, setShowSplash] = useState(true);
   const splashTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const [showGridReference, setShowGridReference] = useState(false);
+  const gridReferenceTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   // Auto-dismiss splash after 4 seconds
   useEffect(() => {
@@ -177,6 +179,28 @@ const Canvas: React.FC<CanvasProps> = ({
       if (splashTimerRef.current) clearTimeout(splashTimerRef.current);
     };
   }, [fragments.length, showSplash]);
+
+  // Auto-hide grid reference after 5 seconds
+  useEffect(() => {
+    if (gridReferenceTimerRef.current) {
+      clearTimeout(gridReferenceTimerRef.current);
+      gridReferenceTimerRef.current = null;
+    }
+    if (isGridVisible) {
+      setShowGridReference(true);
+      gridReferenceTimerRef.current = setTimeout(() => {
+        setShowGridReference(false);
+        gridReferenceTimerRef.current = null;
+      }, 5000);
+    } else {
+      setShowGridReference(false);
+    }
+    return () => {
+      if (gridReferenceTimerRef.current) {
+        clearTimeout(gridReferenceTimerRef.current);
+      }
+    };
+  }, [isGridVisible]);
 
   // Reset splash when canvas is cleared
   useEffect(() => {
@@ -521,7 +545,7 @@ const Canvas: React.FC<CanvasProps> = ({
       )}
 
       {/* Grid Scale Indicator */}
-      {isGridVisible && (
+      {isGridVisible && showGridReference && (
         <div className="absolute bottom-4 left-4 bg-white/95 backdrop-blur-sm rounded-lg shadow-lg border-2 border-blue-400 p-3 z-20 max-w-sm">
           <div className="flex items-start gap-3">
             <svg

--- a/src/web/web-canvas/src/components/Sidebar.tsx
+++ b/src/web/web-canvas/src/components/Sidebar.tsx
@@ -179,7 +179,7 @@ const Sidebar: React.FC<SidebarProps> = ({
 
   const handleMouseMove = useCallback((e: MouseEvent) => {
     const newWidth = e.clientX;
-    if (newWidth >= 220 && newWidth <= 500) {
+    if (newWidth >= 220 && newWidth <= window.innerWidth * 0.85) {
       onWidthChange(newWidth);
     }
   }, [onWidthChange]);

--- a/src/web/web-canvas/src/components/VirtualizedFragmentList.tsx
+++ b/src/web/web-canvas/src/components/VirtualizedFragmentList.tsx
@@ -121,12 +121,6 @@ const FragmentRow = ({ index, style, data }: ListChildComponentProps<FragmentRow
           )}
         </div>
 
-        {/* Shift-click hint */}
-        <div className="absolute bottom-10 left-0 right-0 flex justify-center pointer-events-none">
-          {!isSelected && (
-            <span className="text-[9px] text-slate-300 font-medium">shift+click or right-click to select</span>
-          )}
-        </div>
       </div>
     </div>
   );


### PR DESCRIPTION

- Remove shift+click hint text from fragment cards in the left navbar
- Increase sidebar max width from 500px to 85% of viewport
- Auto-hide Grid Scale Reference after 5 seconds when grid is toggled on

closes #206  closes #207 